### PR TITLE
Defined and Implemented API Routes for the Tag table

### DIFF
--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -58,8 +58,22 @@ router.put('/:id', async (req, res) => {
   }
 });
 
-router.delete('/:id', (req, res) => {
+router.delete('/:id', async (req, res) => {
   // delete on tag by its `id` value
+  try {
+    const deleteRequestData = await Tag.destroy({
+      where: {
+        id: req.params.id
+      }
+    });
+    if (!deleteRequestData) {
+      res.status(400).json({ message: "No tag was found with that id." });
+      return;
+    }
+    res.status(200).json(deleteRequestData);
+  } catch (err) {
+    res.status(400).json(err);
+  }
 });
 
 module.exports = router;

--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -3,9 +3,17 @@ const { Tag, Product, ProductTag } = require('../../models');
 
 // The `/api/tags` endpoint
 
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   // find all tags
   // be sure to include its associated Product data
+  try {
+    const tagData = await Tag.findAll({
+      include: [{ model: Product }] // Be mindful it is `include`, not `includes`, no error will be generated but you will not receive the product information
+    });
+    res.status(200).json(tagData);
+  } catch (err) {
+    res.status(400).json(err)
+  };
 });
 
 router.get('/:id', (req, res) => {

--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -16,9 +16,17 @@ router.get('/', async (req, res) => {
   };
 });
 
-router.get('/:id', (req, res) => {
+router.get('/:id', async (req, res) => {
   // find a single tag by its `id`
   // be sure to include its associated Product data
+  try {
+    const tagData = await Tag.findByPk(req.params.id, {
+      include: [{ model: Product}]
+    });
+    res.status(200).json(tagData);
+  } catch (err) {
+    res.status(400).json(err)
+  }
 });
 
 router.post('/', (req, res) => {

--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -29,8 +29,16 @@ router.get('/:id', async (req, res) => {
   }
 });
 
-router.post('/', (req, res) => {
+router.post('/', async (req, res) => {
   // create a new tag
+  try {
+    const newTagData = await Tag.create({
+      tag_name: req.body.tag_name
+    });
+    res.status(201).json(newTagData);
+  } catch (err) {
+    res.status(400).json(err);
+  }
 });
 
 router.put('/:id', (req, res) => {

--- a/routes/api/tag-routes.js
+++ b/routes/api/tag-routes.js
@@ -41,8 +41,21 @@ router.post('/', async (req, res) => {
   }
 });
 
-router.put('/:id', (req, res) => {
+router.put('/:id', async (req, res) => {
   // update a tag's name by its `id` value
+  try {
+    const updateData = await Tag.update({
+      tag_name: req.body.tag_name
+    },
+    {
+      where: {
+        id: req.params.id
+      }
+    });
+    res.status(201).json(updateData);
+  } catch (err) {
+    res.status(400).json(err);
+  }
 });
 
 router.delete('/:id', (req, res) => {


### PR DESCRIPTION
Defined five routes: 

- A `GET` route to retrieve all tags in the Tag table and their associated products
- A `GET` route to retrieve a single tag, with its associated products, using its `id`
- A `POST` route to add a new tag to the Tag table
- A `PUT` route to update a tag using its `id`
- A `DELETE` route to remove a tag from the Tag table using its `id`